### PR TITLE
Fix dates sorting

### DIFF
--- a/server/views/pages/lduMailboxes/index.njk
+++ b/server/views/pages/lduMailboxes/index.njk
@@ -54,13 +54,13 @@
       {
         text: mailbox.createdAt | formatDate('dd MMM yyyy HH:mm:ss'),
         attributes: {
-          "data-sort-value": mailbox.createdAt
+          "data-sort-value": mailbox.createdAt | formatDate('T')
         }
       },
       {
         text: mailbox.updatedAt | formatDate('dd MMM yyyy HH:mm:ss'),
         attributes: {
-          "data-sort-value": mailbox.updatedAt
+          "data-sort-value": mailbox.updatedAt | formatDate('T')
         }
       }
     ]), tableRows) %}


### PR DESCRIPTION
The dates need to be converted to an epoch timestamp (i.e. `1737043126165`) so the sorting works properly.