### PR TITLE
Rework of validation

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -21,6 +21,7 @@ import routes from './routes'
 import type { Services } from './services'
 
 import populateClientToken from './middleware/populateClientToken'
+import { retrieveValidationErrorsPostRedirect } from './services/validation'
 
 export default function createApp(services: Services): express.Application {
   const app = express()
@@ -42,6 +43,7 @@ export default function createApp(services: Services): express.Application {
   app.use(setUpCsrf())
   app.use(setUpCurrentUser())
   app.use(populateClientToken(services.hmppsAuthClient))
+  app.use(retrieveValidationErrorsPostRedirect)
 
   app.use(routes(services))
 

--- a/server/errorHandler.ts
+++ b/server/errorHandler.ts
@@ -1,7 +1,6 @@
 import type { Request, Response, NextFunction } from 'express'
 import type { HTTPError } from 'superagent'
 import logger from '../logger'
-import { handleValidationWithPageRender, pageToRenderDefined } from './services/validation'
 
 export default function createErrorHandler(production: boolean) {
   return (error: HTTPError, req: Request, res: Response, next: NextFunction): void => {
@@ -10,11 +9,6 @@ export default function createErrorHandler(production: boolean) {
     if (error.status === 401 || error.status === 403) {
       logger.info('Logging user out')
       return res.redirect('/sign-out')
-    }
-
-    if (error.status === 400 && pageToRenderDefined(req)) {
-      // @ts-expect-error - the type is correct!
-      return handleValidationWithPageRender(req, res, error.data.errors)
     }
 
     res.locals.message = production

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -14,9 +14,9 @@ export default (services: Services): Router => {
   get('/', async (req, res, next) => res.render('pages/index'))
   get('/local-delivery-unit-mailboxes', localDeliveryUnitMailboxes.index(services))
   get('/local-delivery-unit-mailboxes/new', localDeliveryUnitMailboxes.newMailbox)
-  post('/local-delivery-unit-mailboxes', ...localDeliveryUnitMailboxes.create(services))
+  post('/local-delivery-unit-mailboxes', localDeliveryUnitMailboxes.create(services))
   get('/local-delivery-unit-mailboxes/:id/edit', localDeliveryUnitMailboxes.edit(services))
-  post('/local-delivery-unit-mailboxes/:id', ...localDeliveryUnitMailboxes.update(services))
+  post('/local-delivery-unit-mailboxes/:id', localDeliveryUnitMailboxes.update(services))
   get('/local-delivery-unit-mailboxes/:id/delete', localDeliveryUnitMailboxes.confirmDelete(services))
   destroy('/local-delivery-unit-mailboxes/:id', localDeliveryUnitMailboxes.deleteMailbox(services))
 

--- a/server/routes/localDeliveryUnitMailboxes/controller.ts
+++ b/server/routes/localDeliveryUnitMailboxes/controller.ts
@@ -1,6 +1,6 @@
 import { body, matchedData } from 'express-validator'
 import { RequestHandler, RequestHandlerWithServices, ValidatedRequestHandlerWithServices } from '../../services'
-import { renderPageOnValidationError } from '../../services/validation'
+import { validatedRequest } from '../../services/validation'
 
 export const index: RequestHandlerWithServices =
   ({ mailboxRegisterService }) =>
@@ -11,31 +11,35 @@ export const index: RequestHandlerWithServices =
     res.render('pages/lduMailboxes/index', { mailboxes })
   }
 
-export const create: ValidatedRequestHandlerWithServices = ({ mailboxRegisterService }) => [
-  body('name'),
-  body('emailAddress').isEmail().withMessage('Please enter a valid email address'),
-  body('country'),
-  body('unitCode').notEmpty().withMessage('Please enter the unit code'),
-  body('areaCode').notEmpty().withMessage('Please enter the area code'),
-  renderPageOnValidationError('pages/lduMailboxes/new'),
+export const create: RequestHandlerWithServices = ({ mailboxRegisterService }) =>
+  validatedRequest(
+    {
+      validations: [
+        body('name'),
+        body('emailAddress').isEmail().withMessage('Please enter a valid email address'),
+        body('country'),
+        body('unitCode').notEmpty().withMessage('Please enter the unit code'),
+        body('areaCode').notEmpty().withMessage('Please enter the area code'),
+      ],
+      onValidationErrorRedirectTo: '/local-delivery-unit-mailboxes/new',
+    },
+    async (req, res, next) => {
+      const { name, emailAddress, country, unitCode, areaCode } = matchedData(req)
 
-  async (req, res, next) => {
-    const { name, emailAddress, country, unitCode, areaCode } = matchedData(req)
+      const mailbox = {
+        name,
+        emailAddress,
+        country,
+        unitCode,
+        areaCode,
+      }
 
-    const mailbox = {
-      name,
-      emailAddress,
-      country,
-      unitCode,
-      areaCode,
-    }
+      // @ts-expect-error - temporary linting bypass
+      await mailboxRegisterService.createLocalDeliveryUnitMailbox(req?.middleware?.clientToken, mailbox)
 
-    // @ts-expect-error - temporary linting bypass
-    await mailboxRegisterService.createLocalDeliveryUnitMailbox(req?.middleware?.clientToken, mailbox)
-
-    return res.redirect('/local-delivery-unit-mailboxes')
-  },
-]
+      return res.redirect('/local-delivery-unit-mailboxes')
+    },
+  )
 
 export const newMailbox: RequestHandler = async (req, res, next) => res.render('pages/lduMailboxes/new')
 
@@ -50,26 +54,30 @@ export const edit: RequestHandlerWithServices =
     res.render('pages/lduMailboxes/edit', { mailbox })
   }
 
-export const update: ValidatedRequestHandlerWithServices = ({ mailboxRegisterService }) => [
-  renderPageOnValidationError('pages/lduMailboxes/edit'),
-  async (req, res, next) => {
-    const { name, emailAddress, country, unitCode, areaCode } = req.body
-    const { id } = req.params
+export const update: RequestHandlerWithServices = ({ mailboxRegisterService }) =>
+  validatedRequest(
+    {
+      validations: [],
+      onValidationErrorRedirectTo: '/local-delivery-unit-mailboxes/:id/edit',
+    },
+    async (req, res, next) => {
+      const { name, emailAddress, country, unitCode, areaCode } = req.body
+      const { id } = req.params
 
-    const mailbox = {
-      name,
-      emailAddress,
-      country,
-      unitCode,
-      areaCode,
-    }
+      const mailbox = {
+        name,
+        emailAddress,
+        country,
+        unitCode,
+        areaCode,
+      }
 
-    // @ts-expect-error - temporary linting bypass
-    await mailboxRegisterService.updateLocalDeliveryUnitMailbox(req?.middleware?.clientToken, id, mailbox)
+      // @ts-expect-error - temporary linting bypass
+      await mailboxRegisterService.updateLocalDeliveryUnitMailbox(req?.middleware?.clientToken, id, mailbox)
 
-    res.redirect('/local-delivery-unit-mailboxes')
-  },
-]
+      res.redirect('/local-delivery-unit-mailboxes')
+    },
+  )
 
 export const confirmDelete: RequestHandlerWithServices =
   ({ mailboxRegisterService }) =>

--- a/server/routes/localDeliveryUnitMailboxes/controller.ts
+++ b/server/routes/localDeliveryUnitMailboxes/controller.ts
@@ -1,5 +1,5 @@
 import { body, matchedData } from 'express-validator'
-import { RequestHandler, RequestHandlerWithServices, ValidatedRequestHandlerWithServices } from '../../services'
+import { RequestHandler, RequestHandlerWithServices } from '../../services'
 import { validatedRequest } from '../../services/validation'
 
 export const index: RequestHandlerWithServices =

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -19,6 +19,4 @@ export const services = () => {
 
 export type Services = ReturnType<typeof services>
 export type RequestHandlerWithServices = (services?: Services) => RequestHandler
-export type MultipleRequestHandlerWithServices = (services?: Services) => RequestHandler[]
-export type ValidatedRequestHandlerWithServices = MultipleRequestHandlerWithServices
 export { RequestHandler }

--- a/server/services/validation.test.ts
+++ b/server/services/validation.test.ts
@@ -1,0 +1,13 @@
+import { Request } from 'express'
+import { redirectPath } from './validation'
+
+describe('redirectPath', () => {
+  it('replaces param placeholders in the redirection path with params from the current request', () => {
+    const req = {
+      params: { id: 123, modifier: 'ABC', another: 'awesome', oneMore: 'left untouched' },
+    } as unknown as Request
+    expect(redirectPath('/a-cool-resource/:id/edit/:modifier/:another', req)).toEqual(
+      '/a-cool-resource/123/edit/ABC/awesome',
+    )
+  })
+})


### PR DESCRIPTION
Making the controller actions easier to unit test by changing the method signature from RequestHandler[] to just RequestHandler.

Handling of back end 400 errors is explicit in the validation method rather than separate in the global error handler